### PR TITLE
Add OpenAI photo generation and delete confirmation

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,40 +91,15 @@
                 </g>
               </g>
             </g>
-            <g class="hamster hamster-photo is-hidden" id="hamster-photo">
-              <ellipse class="shadow" cx="110" cy="240" rx="66" ry="16"></ellipse>
-              <g class="body-group">
-                <ellipse class="body" cx="110" cy="144" rx="76" ry="98"></ellipse>
-                <ellipse class="belly" cx="110" cy="172" rx="48" ry="66"></ellipse>
-                <g class="ears">
-                  <ellipse class="ear" cx="58" cy="54" rx="28" ry="30"></ellipse>
-                  <ellipse class="ear" cx="162" cy="54" rx="28" ry="30"></ellipse>
-                  <ellipse class="ear-inner" cx="58" cy="58" rx="18" ry="22"></ellipse>
-                  <ellipse class="ear-inner" cx="162" cy="58" rx="18" ry="22"></ellipse>
-                </g>
-                <g class="face">
-                  <ellipse class="cheek" cx="84" cy="128" rx="20" ry="18"></ellipse>
-                  <ellipse class="cheek" cx="136" cy="128" rx="20" ry="18"></ellipse>
-                  <ellipse class="eye" cx="88" cy="110" rx="11" ry="13"></ellipse>
-                  <ellipse class="eye" cx="132" cy="110" rx="11" ry="13"></ellipse>
-                  <circle class="eye-highlight" cx="84" cy="104" r="3"></circle>
-                  <circle class="eye-highlight" cx="128" cy="104" r="3"></circle>
-                  <path class="nose" d="M108 122 q4 -4 8 0 v10 h-8z"></path>
-                  <path class="mouth" d="M100 138 q10 10 20 0" fill="none"></path>
-                  <path class="chin" d="M104 146 q6 6 12 0" fill="none"></path>
-                  <g class="whiskers">
-                    <path d="M64 126 h32" />
-                    <path d="M64 138 h28" />
-                    <path d="M156 126 h-32" />
-                    <path d="M156 138 h-28" />
-                  </g>
-                </g>
-                <g class="paws">
-                  <ellipse cx="74" cy="214" rx="22" ry="26"></ellipse>
-                  <ellipse cx="146" cy="214" rx="22" ry="26"></ellipse>
-                </g>
-              </g>
-            </g>
+            <image
+              id="hamster-photo"
+              class="hamster-photo-image is-hidden"
+              x="10"
+              y="20"
+              width="200"
+              height="220"
+              preserveAspectRatio="xMidYMid slice"
+            ></image>
             <g id="fashion-layer"></g>
             <g id="effect-layer"></g>
           </svg>

--- a/server.js
+++ b/server.js
@@ -57,6 +57,56 @@ app.post("/api/fashion-story", async (req, res) => {
   }
 });
 
+app.post("/api/hamster-photo", async (req, res) => {
+  if (!openaiClient) {
+    return res.status(500).json({ error: "Missing OpenAI API key on the server." });
+  }
+
+  const selections = Array.isArray(req.body?.selections) ? req.body.selections : [];
+  const accessories = selections
+    .filter((item) => item && typeof item === "object")
+    .map((item) => {
+      const name = typeof item.name === "string" && item.name.trim() ? item.name.trim() : null;
+      const category = typeof item.category === "string" && item.category.trim() ? item.category.trim() : null;
+      const description = typeof item.description === "string" && item.description.trim() ? item.description.trim() : null;
+      const base = name || "accessory";
+      if (description) {
+        return `${base} — ${description}`;
+      }
+      if (category) {
+        return `${base} (${category})`;
+      }
+      return base;
+    });
+
+  const wardrobeDescription = accessories.length
+    ? `The hamster is styled with ${accessories.join(", ")}.`
+    : "The hamster is not wearing accessories yet but should look ready for the runway.";
+
+  const photoPrompt = `High-resolution studio photograph of an adorable hamster fashion model standing on a small runway. ${wardrobeDescription} Dramatic but soft lighting, shallow depth of field, crisp focus, vibrant colors, 35mm lens photography, professional magazine shoot.`;
+
+  try {
+    const imageResponse = await openaiClient.images.generate({
+      model: "gpt-image-1",
+      prompt: photoPrompt,
+      size: "512x512",
+      response_format: "b64_json",
+      quality: "standard",
+    });
+
+    const imageBase64 = imageResponse.data?.[0]?.b64_json;
+    if (!imageBase64) {
+      throw new Error("No image returned from OpenAI image API");
+    }
+
+    const dataUrl = `data:image/png;base64,${imageBase64}`;
+    res.json({ image: dataUrl });
+  } catch (error) {
+    console.error("Failed to generate hamster photo", error);
+    res.status(500).json({ error: "Unable to generate hamster photograph." });
+  }
+});
+
 app.use((_req, res) => {
   res.sendFile(path.join(__dirname, "index.html"));
 });

--- a/styles.css
+++ b/styles.css
@@ -77,6 +77,12 @@ body {
   display: block;
 }
 
+.hamster-photo-image {
+  clip-path: inset(0 round 22px);
+  image-rendering: auto;
+  transition: opacity 0.4s ease;
+}
+
 .stage {
   fill: url(#stageGradient);
 }
@@ -156,43 +162,6 @@ body {
 }
 
 .hamster-photo .ears .ear {
-  fill: url(#photoFur);
-}
-
-.hamster-photo .ears .ear-inner {
-  fill: url(#photoEar);
-}
-
-.hamster-photo .face .cheek {
-  fill: rgba(255, 182, 193, 0.75);
-}
-
-.hamster-photo .face .eye {
-  fill: #1f2937;
-}
-
-.hamster-photo .face .eye-highlight {
-  fill: rgba(255, 255, 255, 0.85);
-}
-
-.hamster-photo .face .nose {
-  fill: #5b3318;
-}
-
-.hamster-photo .face .mouth,
-.hamster-photo .face .chin {
-  stroke: rgba(75, 40, 15, 0.9);
-  stroke-width: 3;
-  stroke-linecap: round;
-}
-
-.hamster-photo .whiskers path {
-  stroke: rgba(75, 40, 15, 0.85);
-  stroke-width: 2.5;
-  stroke-linecap: round;
-}
-
-.hamster-photo .paws ellipse {
   fill: url(#photoFur);
 }
 


### PR DESCRIPTION
## Summary
- replace the faux photograph SVG with a real image slot and styling tweaks
- call OpenAI's image generation API via a new /api/hamster-photo endpoint and drive it from the UI with caching and error handling
- require confirmation before removing a saved outfit

## Testing
- node --check server.js
- node --check script.js

------
https://chatgpt.com/codex/tasks/task_e_68daa52fd944832db3d590a553872eb2